### PR TITLE
Removing --json flag from force:package:version:create command to fix Heroku pipeline output not showing

### DIFF
--- a/lib/sfdc.sh
+++ b/lib/sfdc.sh
@@ -238,7 +238,7 @@ install_package_version() {
     -n $VERSION_NUMBER \
     -v $DEVHUB_USERNAME \
     -w 100 \
-    --json -x "
+    -x "
 
   if [ ! "$STAGE" == "DEV" ]; then
     COMMAND_CREATE="${COMMAND_CREATE}-c"


### PR DESCRIPTION
Currently, the package version creation fails silently with no output provided in the Heroku pipeline. example:

```
       Removing scratch org ...
Successfully marked scratch org scratch-1615900187 for deletion
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
       Prepare Environment configs ...
       Installing new package version ...
       New Package Version: 1.0.0.0
       Creating new Package Version
       This may take some time ...
 !     Push rejected, failed to compile aquiva-sfdx-buildpack app.
 !     Push failed
```

Removing `--json` flag from ` force:package:version:create` command fixes it.

```
       Prepare Environment configs ...
       Installing new package version ...
       New Package Version: 1.1.0.0
       Creating new Package Version
       This may take some time ...
ERROR running force:package:version:create:  The Lightning Component Definition 'alexbariyev:AccountLocator' in this managed package must be marked 'access=global'.
 !     Push rejected, failed to compile aquiva-sfdx-buildpack app.
 !     Push failed
```